### PR TITLE
docs: configure Cloudflare Pages deployment with custom domain

### DIFF
--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -11,8 +11,8 @@ const config: Config = {
     v4: true,
   },
 
-  url: 'https://criteria4s.rafaelfernandez.dev',
-  baseUrl: '/',
+  url: 'https://eff3ct0.github.io',
+  baseUrl: '/criteria4s/',
 
   organizationName: 'eff3ct0',
   projectName: 'criteria4s',

--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -11,8 +11,8 @@ const config: Config = {
     v4: true,
   },
 
-  url: 'https://eff3ct0.github.io',
-  baseUrl: '/criteria4s/',
+  url: 'https://criteria4s.rafaelfernandez.dev',
+  baseUrl: '/',
 
   organizationName: 'eff3ct0',
   projectName: 'criteria4s',

--- a/website/static/CNAME
+++ b/website/static/CNAME
@@ -1,1 +1,0 @@
-criteria4s.rafaelfernandez.dev


### PR DESCRIPTION
Update `url` and `baseUrl` in `docusaurus.config.ts` to target `https://criteria4s.rafaelfernandez.dev` served via Cloudflare Pages.